### PR TITLE
feat: Add public folder and EJS views

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "bcryptjs": "^3.0.2",
         "cors": "^2.8.5",
         "dotenv": "^16.0.3",
+        "ejs": "^3.1.10",
         "express": "^4.18.2",
         "express-rate-limit": "^7.3.1",
         "express-recaptcha": "^5.1.0",
@@ -3716,6 +3717,21 @@
       "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
       "license": "MIT"
     },
+    "node_modules/ejs": {
+      "version": "3.1.10",
+      "resolved": "https://registry.npmjs.org/ejs/-/ejs-3.1.10.tgz",
+      "integrity": "sha512-UeJmFfOrAQS8OJWPZ4qtgHyWExa088/MtK5UEyoJGFH67cDEXkZSviOiKRCZ4Xij0zxI3JECgYs3oKx+AizQBA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "jake": "^10.8.5"
+      },
+      "bin": {
+        "ejs": "bin/cli.js"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/electron-to-chromium": {
       "version": "1.5.203",
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.203.tgz",
@@ -4315,6 +4331,36 @@
       "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/filelist": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/filelist/-/filelist-1.0.4.tgz",
+      "integrity": "sha512-w1cEuf3S+DrLCQL7ET6kz+gmlJdbq9J7yXCSjK/OZCPA+qEN1WyF4ZAf0YYJa4/shHJra2t/d/r8SV4Ji+x+8Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "minimatch": "^5.0.1"
+      }
+    },
+    "node_modules/filelist/node_modules/brace-expansion": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
+      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/filelist/node_modules/minimatch": {
+      "version": "5.1.6",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.6.tgz",
+      "integrity": "sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==",
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/fill-range": {
       "version": "7.1.1",
@@ -5488,6 +5534,23 @@
       },
       "optionalDependencies": {
         "@pkgjs/parseargs": "^0.11.0"
+      }
+    },
+    "node_modules/jake": {
+      "version": "10.9.4",
+      "resolved": "https://registry.npmjs.org/jake/-/jake-10.9.4.tgz",
+      "integrity": "sha512-wpHYzhxiVQL+IV05BLE2Xn34zW1S223hvjtqk0+gsPrwd/8JNLXJgZZM/iPFsYc1xyphF+6M6EvdE5E9MBGkDA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "async": "^3.2.6",
+        "filelist": "^1.0.4",
+        "picocolors": "^1.1.1"
+      },
+      "bin": {
+        "jake": "bin/cli.js"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/jest": {

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "bcryptjs": "^3.0.2",
     "cors": "^2.8.5",
     "dotenv": "^16.0.3",
+    "ejs": "^3.1.10",
     "express": "^4.18.2",
     "express-rate-limit": "^7.3.1",
     "express-recaptcha": "^5.1.0",

--- a/public/css/style.css
+++ b/public/css/style.css
@@ -1,0 +1,11 @@
+body {
+    font-family: Arial, sans-serif;
+    background-color: #f0f0f0;
+    color: #333;
+    text-align: center;
+    padding: 50px;
+}
+
+h1 {
+    color: #0056b3;
+}

--- a/src/api/controllers/view.controller.js
+++ b/src/api/controllers/view.controller.js
@@ -1,0 +1,10 @@
+const httpStatus = require('http-status');
+const catchAsync = require('@/utils/catchAsync');
+
+const renderIndex = catchAsync(async (req, res) => {
+  res.render('index');
+});
+
+module.exports = {
+  renderIndex,
+};

--- a/src/api/routes/v1/index.js
+++ b/src/api/routes/v1/index.js
@@ -3,6 +3,7 @@ const authRoute = require('./auth.route');
 const userRoute = require('./user.route');
 const sessionRoute = require('./session.route');
 const productRoute = require('./product.route');
+const viewRoute = require('./view.route');
 const categoryRoute = require('./category.route');
 const pdfRoute = require('./pdf.route');
 
@@ -32,6 +33,10 @@ const defaultRoutes = [
   {
     path: '/pdf',
     route: pdfRoute,
+  },
+  {
+    path: '/',
+    route: viewRoute,
   },
 ];
 

--- a/src/api/routes/v1/view.route.js
+++ b/src/api/routes/v1/view.route.js
@@ -1,0 +1,8 @@
+const express = require('express');
+const viewController = require('@/api/controllers/view.controller');
+
+const router = express.Router();
+
+router.get('/', viewController.renderIndex);
+
+module.exports = router;

--- a/src/app.js
+++ b/src/app.js
@@ -10,8 +10,13 @@ const { errorConverter, errorHandler } = require('@/middlewares/error.middleware
 const ApiError = require('@/utils/ApiError');
 const passport = require('passport');
 const { jwtStrategy } = require('@/config/passport');
+const path = require('path');
 
 const app = express();
+
+// view engine setup
+app.set('views', path.join(__dirname, 'views'));
+app.set('view engine', 'ejs');
 
 // jwt strategy
 passport.use(jwtStrategy);
@@ -29,6 +34,9 @@ app.use(express.json());
 
 // parse urlencoded request body
 app.use(express.urlencoded({ extended: true }));
+
+// serve static files
+app.use(express.static(path.join(__dirname, '../public')));
 
 // sanitize request data
 app.use(xss());

--- a/src/views/index.ejs
+++ b/src/views/index.ejs
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>EJS View</title>
+    <link rel="stylesheet" href="/css/style.css">
+</head>
+<body>
+    <h1>Hello from EJS!</h1>
+    <p>This is a sample view rendered with EJS.</p>
+</body>
+</html>

--- a/tests/integration/view.test.js
+++ b/tests/integration/view.test.js
@@ -1,0 +1,13 @@
+const request = require('supertest');
+const httpStatus = require('http-status');
+const app = require('@/app');
+
+describe('View routes', () => {
+  describe('GET /v1/', () => {
+    it('should return 200 and render the index view', async () => {
+      const res = await request(app).get('/v1/').expect(httpStatus.OK);
+
+      expect(res.text).toContain('<h1>Hello from EJS!</h1>');
+    });
+  });
+});


### PR DESCRIPTION
- Add a `public` folder for static assets.
- Add a `views` folder for EJS templates.
- Configure Express to use EJS as the view engine and serve static files.
- Add a sample view and a route to render it.
- Add an integration test to verify the new view route.